### PR TITLE
Add a dependency on args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Add a dependency on the `args` package.
+
 ## 1.0.2
 
 * Add a dependency on the `logging` package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 1.0.2
+version: 1.0.3
 author: Daniel Davidson <dbdavidson@yahoo.com>
 homepage: https://github.com/patefacio/json_schema
 description: >
@@ -10,6 +10,7 @@ dependencies:
 
   path: "^1.3.0"
   logging: ">=0.9.3<0.12.0"
+  args: ">=0.12.0 <0.14.0"
 
 # end <json_schema dependencies>
 


### PR DESCRIPTION
The "schemadot" executable uses this, so it needs to be declared.