### PR TITLE
Remove duplicate `yaml` dependency.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,9 +27,6 @@ dev_dependencies:
   yaml: "^2.1.0"
   coverage: ">=0.7.6"
 
-environment:
-  sdk: ">=1.8.0 <2.0.0"
-
 # end <json_schema dev dependencies>
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 1.0.4
+version: 1.0.5
 author: Daniel Davidson <dbdavidson@yahoo.com>
 homepage: https://github.com/patefacio/json_schema
 description: >
@@ -18,7 +18,6 @@ dependencies:
 # end <json_schema dependencies>
 
 dev_dependencies:
-  yaml: "any"
   browser: "any"
 
 # custom <json_schema dev dependencies>


### PR DESCRIPTION
This duplicate entry is breaking `pub get|upgrade`:

```
Error on line 27, column 3 of /Users/me/.pub-cache/hosted/pub.dartlang.org/json_schema-1.0.3/pubspec.yaml: Duplicate mapping key.
  yaml: "^2.1.0"
  ^^^^
```

/cc @patefacio 