### PR TITLE
Bump args dependency to include 1.0 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+* Update dependency constraint on the `args` package.
+
 ## 1.0.3
 
 * Add a dependency on the `args` package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 1.0.6
+version: 1.0.7
 author: Daniel Davidson <dbdavidson@yahoo.com>
 homepage: https://github.com/patefacio/json_schema
 description: >
@@ -13,7 +13,7 @@ dependencies:
 
   path: "^1.3.0"
   logging: ">=0.9.3<0.12.0"
-  args: ">=0.11.0 <0.14.0"
+  args: ">=0.11.0 <2.0.0"
 
 # end <json_schema dependencies>
 


### PR DESCRIPTION
This just bumps the upper bound of the args package to include 1.0 packages.  Fixes https://github.com/patefacio/json_schema/issues/8 .